### PR TITLE
hotfix: rename main -> master branch in workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,7 @@ name: Checks
 
 on:
   pull_request:
-    branches: [ main, dev ]
+    branches: [ master, dev ]
 
 jobs:
   check:

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -3,7 +3,7 @@ name: New release
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
needed to trigger jobs on master